### PR TITLE
chore(refresh): refreshed configuration and documentation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -43,7 +43,8 @@ ssh admin@<router-ip>
 - Import the full config to verify no syntax errors: `/import file-name=<filename>.rsc`
 - Verify individual subsystems after import (firewall, mangle, routes, NAT)
 - For `AUTO-BALANCE.rsc`: run the script and confirm mangle/route/NAT rules were created for each WAN link
-- **No automated linting or CI/CD exists** in this repository -- all validation is manual
+- **No automated linting or testing exists** in this repository -- all validation is manual
+- A `release.yaml` workflow creates releases automatically on push to `main`
 
 ### Expected Timing
 
@@ -63,7 +64,9 @@ routeros-samples/
 │   ├── AUTO-BALANCE.rsc     # Standalone script: auto-discovers PPPoE + DHCP WANs, builds PCC rules
 │   └── RB750Gr3.rsc         # RB750Gr3 config (RouterOS 6.47.10) - dual-WAN PCC load balancing
 ├── .github/
-│   └── copilot-instructions.md
+│   ├── copilot-instructions.md
+│   └── workflows/
+│       └── release.yaml      # Automated release on push to main
 ├── CHANGELOG.md
 ├── CONTRIBUTING.md
 ├── LICENSE                  # GNU General Public License v3.0
@@ -159,7 +162,7 @@ ISP 2 ──► ether2 (WAN2) ──┘
 
 ## CI/CD Pipeline
 
-There is **no CI/CD automation** in this repository. All testing is manual on RouterOS hardware or a [MikroTik CHR](https://mikrotik.com/download) VM.
+There is **no automated linting or testing**. All script validation is manual on RouterOS hardware or a [MikroTik CHR](https://mikrotik.com/download) VM. A `release.yaml` workflow handles automated release creation on push to `main`.
 
 ## Development Workflow
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,14 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
+### Added
+
+- created `CLAUDE.md` with architecture, conventions, and validation guidance for Claude Code sessions
+
+### Changed
+
+- refreshed `.github/copilot-instructions.md` to correct CI/CD claims and add `release.yaml` to the repository structure tree
+
 ## [0.1.1] - 2026-04-28
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,42 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Overview
+
+Collection of production-ready MikroTik RouterOS configuration scripts (`.rsc`) for Layer 7 content filtering and multi-WAN load balancing. No build system or package manager -- all scripts are standalone files interpreted by the RouterOS CLI.
+
+## Validation
+
+No automated linting or tests. Validate scripts manually on a RouterOS device or [CHR](https://mikrotik.com/download) VM:
+
+```sh
+scp my-script.rsc admin@<router-ip>:/
+ssh admin@<router-ip>
+/import file-name=my-script.rsc
+```
+
+Verify with: `/ip firewall filter print`, `/ip firewall mangle print`, `/ip route print`, `/ip firewall nat print`.
+
+## Architecture
+
+**Layer 7 Filter configs** (`Layer7 Filter/`): single-WAN with segmented LAN. `ether1` = WAN, `ether2` = open (unrestricted) output, `ether3-5` bridged as protected output. Firewall chain order matters: accept whitelisted destinations, reject HTTPS (443), reject push notifications (2195), reject Layer 7 matches, reject all remaining -- all with ICMP network-unreachable.
+
+**Load Balancer configs** (`LoadBalancer/`): dual-WAN PCC-based load balancing. `AUTO-BALANCE.rsc` auto-discovers PPPoE and DHCP WAN interfaces, cleans up previous rules, and rebuilds mangle/route/NAT entries using `both-addresses` as the PCC classifier. `RB750Gr3.rsc` is a complete device config with the auto-balance script embedded.
+
+## Conventions
+
+- `:local` for function-scoped variables, `:global` for shared state across script blocks.
+- Iterate interfaces with `:foreach p in=[/interface ... find]`.
+- Firewall rules are order-dependent: whitelist first, specific blocks next, reject-all last.
+- Device-specific configs: `<DeviceModel>.rsc` or `<DeviceModel>v<N>.rsc` for revisions.
+- Automation scripts: ALL-CAPS naming (e.g., `AUTO-BALANCE.rsc`).
+- Layer 7 configs go in `Layer7 Filter/`, load balancing configs in `LoadBalancer/`.
+
+## CI
+
+A `release.yaml` workflow creates releases automatically on push to `main`. No automated linting or testing.
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for prerequisites, workflow, and commit conventions.


### PR DESCRIPTION
Automated weekly refresh by `config-and-docs-refresh.yaml` in `rios0rios0/config-automation`.

Claude Code reviewed the in-scope configuration and documentation files (currently `CLAUDE.md` and `.github/copilot-instructions.md`) against the current code, updated whichever drifted, and recorded the change in `CHANGELOG.md` (when the repo has one).

Review the diff carefully --- this PR was generated by Claude Code and may contain inaccuracies.